### PR TITLE
Reformatted Changes file as per CPAN::Changes::Spec

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,4 @@
-Revision history for Perl extension WWW::Mechanize::Cached
+Revision history for Perl module WWW::Mechanize::Cached
 
 1.42 2013-06-29
     - Allow caching w/ Content-Encoding == chunked + no size header (Kent
@@ -46,72 +46,74 @@ Revision history for Perl extension WWW::Mechanize::Cached
     - Applied patch from RT http://rt.cpan.org/Public/Bug/Display.html?id=42693
       This fixes the "Can't store CODE items" errors
     - Now requires Test::Warn 0.11 (fixes errors in t/002-bad-custom-cache.t)
-    - Moved development to GitHub: http://github.com/oalders/www-mechanize-cached/tree/master
+    - Moved development to GitHub:
+      http://github.com/oalders/www-mechanize-cached/tree/master
     - Added Perl::Critic author tests
 
-1.32    Sun Apr 11 22:19:49 CDT 2004
+1.32 2004-04-11
 
-        [ENHANCEMENTS]
-        * Added the $mech->is_cached() method.
+    [ENHANCEMENTS]
+    - Added the $mech->is_cached() method.
 
-        * Verified that reusing an existing cache gives you the pages back.
+    - Verified that reusing an existing cache gives you the pages back.
 
-        [INTERNAL]
-        * Now requires WWW::Mechanize 1.00, because previous versions
-          goofed up the HTTP headers on some requests.
-
-
-1.30    Sun Mar 14 02:51:19 CST 2004
-
-        No new features.
-
-        [FIXED]
-        * Fixed stupid configuration problem in t/bad-cache-test.t.
-          If you got 1.28 installed OK, you don't need 1.30.
-
-1.28    Sat Mar 13 22:05:26 CST 2004
-
-        [THINGS THAT WILL BREAK YOUR CODE]
-        * The C<cache> parm to the constructor is no longer a set
-          of parms to specify how the cache will be initialized.  It
-          must now be a fully-initialized cache object, probably in
-          the Cache::Cache hierarchy.
-
-        * Existing caches will not work, because I changed the
-          directory that they get written to.  It used to go into
-          /tmp/FileCache/WWW::Mechanize::Cached, but now will go into
-          /tmp/FileCache/www-mechanize-cached.  This is so the Windows
-          folks can use the module, too.
-
-          However, if you want to create your own cache object that
-          writes to /tmp/FileCache/WWW::Mechanize::Cached, for
-          compatibility, you can create it and pass it in.
-
-        [ENHANCEMENTS]
-        * You can now specify your own Cache::Cache object to pass
-          into the constructor.
-
-1.26    Sun Feb 29 23:59:48 CST 2004
-
-        [FIXES]
-        * Removed a duplicate $key.  Cleaned up some of the internal code,
-          and made the variable names more explicit.
-
-        * Added an autocheck=>1 to the t/cached.t test.  Also hits
-          time.gov instead of Iain's now-gone website.
-
-        * Removed the SIGNATURE, which I don't intend to maintain.
-
-1.24    Sun Jan 18 23:10:40 CST 2004
-
-        NO NEW FUNCTIONALITY.
-
-        On December 29th, 2003, Iain Truskett, the original author of
-        WWW::Mechanize::Cached passed away.  I've taken over maintenance
-        of the module.  If you're interested in carrying on Iain's work,
-        let me know.
+    [INTERNAL]
+    - Now requires WWW::Mechanize 1.00, because previous versions
+      goofed up the HTTP headers on some requests.
 
 
-1.23    December 1, 2003
-        Initial version, released by Iain Truskett.
+1.30 2004-03-14
+
+    - No new features.
+
+    [FIXED]
+    - Fixed stupid configuration problem in t/bad-cache-test.t.
+      If you got 1.28 installed OK, you don't need 1.30.
+
+1.28 2004-03-13
+
+    [THINGS THAT WILL BREAK YOUR CODE]
+    - The C<cache> parm to the constructor is no longer a set
+      of parms to specify how the cache will be initialized.  It
+      must now be a fully-initialized cache object, probably in
+      the Cache::Cache hierarchy.
+
+    - Existing caches will not work, because I changed the
+      directory that they get written to.  It used to go into
+      /tmp/FileCache/WWW::Mechanize::Cached, but now will go into
+      /tmp/FileCache/www-mechanize-cached.  This is so the Windows
+      folks can use the module, too.
+
+      However, if you want to create your own cache object that
+      writes to /tmp/FileCache/WWW::Mechanize::Cached, for
+      compatibility, you can create it and pass it in.
+
+    [ENHANCEMENTS]
+    - You can now specify your own Cache::Cache object to pass
+      into the constructor.
+
+1.26 2004-02-29
+
+    [FIXES]
+    - Removed a duplicate $key.  Cleaned up some of the internal code,
+      and made the variable names more explicit.
+
+    - Added an autocheck=>1 to the t/cached.t test.  Also hits
+      time.gov instead of Iain's now-gone website.
+
+    - Removed the SIGNATURE, which I don't intend to maintain.
+
+1.24 2004-01-18
+
+    NO NEW FUNCTIONALITY.
+
+    On December 29th, 2003, Iain Truskett, the original author of
+    WWW::Mechanize::Cached passed away.  I've taken over maintenance
+    of the module.  If you're interested in carrying on Iain's work,
+    let me know.
+
+
+1.23 2003-12-01
+
+    - Initial version, released by Iain Truskett.
 


### PR DESCRIPTION
Every good turn deserves another.

This fixes up your Changes file to meet the lightweight format specific in CPAN::Changes::Spec.
This was mainly reformatted dates for older releases to be in ISO 8601 format.

When you release this, you'll only have one non-confirming dist: http://changes.cpanhq.org/author/OALDERS

Cheers,
Neil
