### PR TITLE
Remove warnings on new()

### DIFF
--- a/lib/WWW/Mechanize/Cached.pm
+++ b/lib/WWW/Mechanize/Cached.pm
@@ -33,6 +33,28 @@ has cache_mismatch_content_length => (
 
 has cache => ( is => 'lazy', isa => \&_isa_warn_cache );
 
+sub FOREIGNBUILDARGS {
+    my ($class, %args) = @_;
+
+    # WWW::Mechanize/LWP::UserAgent would complain about these
+    for my $attribute (
+        qw(
+            is_cached
+            positive_cache
+            ref_in_cach_key
+            _verbose_dwarn
+            cache_undef_content_length
+            cache_zero_content_length
+            cache_mismatch_content_length
+            cache
+        )
+    ) {
+        delete $args{ $attribute };
+    }
+
+    return %args;
+}
+
 sub _isa_warn_cache {
     return
             if 'HASH' ne ref $_[0]

--- a/t/007-initialize-warnings.t
+++ b/t/007-initialize-warnings.t
@@ -1,0 +1,67 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use WWW::Mechanize::Cached;
+
+BEGIN {
+    eval "use Test::Warn";
+    plan skip_all => "Test::Warn required for testing initialization warnings"
+        if $@;
+}
+
+use lib 't';
+use TestCache;
+
+my $cache = TestCache->new();
+isa_ok( $cache, 'TestCache' );
+
+my $was_warning = $^W;
+   $^W          = 1;
+
+my $mech;
+
+warnings_are
+    {
+        $mech = WWW::Mechanize::Cached->new(
+            cache => $cache,
+        );
+    }
+    [ ],
+    "No warnings for accepted 'cache' parameter";
+
+for my $boolean_attribute (
+    qw(
+        is_cached
+        positive_cache
+        ref_in_cach_key
+        _verbose_dwarn
+        cache_undef_content_length
+        cache_zero_content_length
+        cache_mismatch_content_length
+    )
+) {
+    warnings_are
+        {
+            $mech = WWW::Mechanize::Cached->new(
+                $boolean_attribute => 1,
+            );
+        }
+        [ ],
+        "No warnings for accepted '$boolean_attribute' parameter";
+}
+
+warnings_exist
+    {
+        $mech = WWW::Mechanize::Cached->new(
+            not_my_argument => 1,
+        );
+    }
+    qr/not_my_argument/,
+    'Unrecognized arguments passed through to WWW::Mechanize';
+
+
+# Put this back
+$^W = $was_warning;
+
+done_testing();


### PR DESCRIPTION
This fixes #15 - it was a little less obvious than I originally thought because `make test` was setting the warnings flag (`$^W`), so you didn't necessarily see that with a simple prove. Added a new test case to cover that.