### PR TITLE
Remove new warnings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module WWW::Mechanize::Cached
 
 {{$NEXT}}
+    - Remove warnings on new() (GH#15) (Jonathan Rubin, simbabque)
 
 1.52      2019-11-18 14:15:37Z
     - Implement invalidate_last_request to remove the last request from the

--- a/lib/WWW/Mechanize/Cached.pm
+++ b/lib/WWW/Mechanize/Cached.pm
@@ -34,6 +34,28 @@ has cache_mismatch_content_length => (
 
 has cache => ( is => 'lazy', isa => \&_isa_warn_cache );
 
+sub FOREIGNBUILDARGS {
+    my ($class, %args) = @_;
+
+    # WWW::Mechanize/LWP::UserAgent would complain about these
+    for my $attribute (
+        qw(
+            is_cached
+            positive_cache
+            ref_in_cach_key
+            _verbose_dwarn
+            cache_undef_content_length
+            cache_zero_content_length
+            cache_mismatch_content_length
+            cache
+        )
+    ) {
+        delete $args{ $attribute };
+    }
+
+    return %args;
+}
+
 sub _isa_warn_cache {
     return
             if 'HASH' ne ref $_[0]

--- a/t/007-initialize-warnings.t
+++ b/t/007-initialize-warnings.t
@@ -1,14 +1,9 @@
 use strict;
 use warnings FATAL => 'all';
+use Test::Warnings qw( :all :no_end_test );
 
 use Test::More;
 use WWW::Mechanize::Cached;
-
-BEGIN {
-    eval "use Test::Warn";
-    plan skip_all => "Test::Warn required for testing initialization warnings"
-        if $@;
-}
 
 use lib 't';
 use TestCache;
@@ -17,49 +12,40 @@ my $cache = TestCache->new();
 isa_ok( $cache, 'TestCache' );
 
 my $was_warning = $^W;
-   $^W          = 1;
+$^W = 1;
 
-my $mech;
-
-warnings_are
-    {
-        $mech = WWW::Mechanize::Cached->new(
-            cache => $cache,
-        );
-    }
-    [ ],
-    "No warnings for accepted 'cache' parameter";
+my $mech = WWW::Mechanize::Cached->new(
+    cache => $cache,
+);
+had_no_warnings("No warnings for accepted 'cache' parameter");
 
 for my $boolean_attribute (
     qw(
-        is_cached
-        positive_cache
-        ref_in_cach_key
-        _verbose_dwarn
-        cache_undef_content_length
-        cache_zero_content_length
-        cache_mismatch_content_length
+    is_cached
+    positive_cache
+    ref_in_cach_key
+    _verbose_dwarn
+    cache_undef_content_length
+    cache_zero_content_length
+    cache_mismatch_content_length
     )
 ) {
-    warnings_are
-        {
-            $mech = WWW::Mechanize::Cached->new(
-                $boolean_attribute => 1,
-            );
-        }
-        [ ],
-        "No warnings for accepted '$boolean_attribute' parameter";
+    $mech = WWW::Mechanize::Cached->new(
+        $boolean_attribute => 1,
+    );
+    had_no_warnings(
+        "No warnings for accepted '$boolean_attribute' parameter");
 }
 
-warnings_exist
-    {
+like(
+    warning {
         $mech = WWW::Mechanize::Cached->new(
             not_my_argument => 1,
         );
-    }
+    },
     qr/not_my_argument/,
-    'Unrecognized arguments passed through to WWW::Mechanize';
-
+    'Unrecognized arguments passed through to WWW::Mechanize'
+);
 
 # Put this back
 $^W = $was_warning;

--- a/t/007-initialize-warnings.t
+++ b/t/007-initialize-warnings.t
@@ -1,0 +1,67 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use WWW::Mechanize::Cached;
+
+BEGIN {
+    eval "use Test::Warn";
+    plan skip_all => "Test::Warn required for testing initialization warnings"
+        if $@;
+}
+
+use lib 't';
+use TestCache;
+
+my $cache = TestCache->new();
+isa_ok( $cache, 'TestCache' );
+
+my $was_warning = $^W;
+   $^W          = 1;
+
+my $mech;
+
+warnings_are
+    {
+        $mech = WWW::Mechanize::Cached->new(
+            cache => $cache,
+        );
+    }
+    [ ],
+    "No warnings for accepted 'cache' parameter";
+
+for my $boolean_attribute (
+    qw(
+        is_cached
+        positive_cache
+        ref_in_cach_key
+        _verbose_dwarn
+        cache_undef_content_length
+        cache_zero_content_length
+        cache_mismatch_content_length
+    )
+) {
+    warnings_are
+        {
+            $mech = WWW::Mechanize::Cached->new(
+                $boolean_attribute => 1,
+            );
+        }
+        [ ],
+        "No warnings for accepted '$boolean_attribute' parameter";
+}
+
+warnings_exist
+    {
+        $mech = WWW::Mechanize::Cached->new(
+            not_my_argument => 1,
+        );
+    }
+    qr/not_my_argument/,
+    'Unrecognized arguments passed through to WWW::Mechanize';
+
+
+# Put this back
+$^W = $was_warning;
+
+done_testing();


### PR DESCRIPTION
Continuation of #16 to switch the new tests to Test::Warnings. Original code by @jrubinator. 

Closes #16
Fixes #15