### PR TITLE
Fix Test::RequiresInternet usage

### DIFF
--- a/t/007-clear-cache.t
+++ b/t/007-clear-cache.t
@@ -3,8 +3,6 @@
 use strict;
 use warnings FATAL => 'all';
 
-use Test::More tests => 13;
-
 use constant {
     ADDRESS           => 'wikipedia.org',
     DIFFERENT_ADDRESS => 'en.wikipedia.org',
@@ -13,6 +11,8 @@ use constant {
 
 use Test::RequiresInternet (ADDRESS) => 443,
     (DIFFERENT_ADDRESS)              => 443;
+
+use Test::More tests => 13;
 
 use WWW::Mechanize::Cached;
 


### PR DESCRIPTION
Since Test::RequiresInternet does the equivalent of a 'skip_all' plan when the connection is not found, it must be used before a different plan is declared. An alternative would be to remove the plan from `use Test::More;` and then do `plan tests => 13;` after using Test::RequiresInternet.