### PR TITLE
remove plan declared before Test::RequiresInternet

### DIFF
--- a/t/007-clear-cache.t
+++ b/t/007-clear-cache.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings FATAL => 'all';
 
-use Test::More tests => 13;
+use Test::More;
 
 use constant {
     ADDRESS           => 'wikipedia.org',


### PR DESCRIPTION
#25 redo. Turns out it was just the one file. Just removing the plan since no other test file uses one and it uses done_testing already.