### PR TITLE
Add dependabot config for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      major-updates:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering the `github-actions` ecosystem on a weekly schedule.
- Two catch-all groups: `major-updates` batches coordinated major bumps (e.g. `upload-artifact` / `download-artifact`) into one PR; `minor-and-patch` rolls up routine updates.
- 7-day cooldown so churning releases get yanked or patched before a PR opens.

## Test plan
- [ ] Dependabot opens at most two grouped PRs per run for actions updates
- [ ] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(open(".github/dependabot.yml"))'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)